### PR TITLE
redirect_uri_mismatch 문제와 관련한 callback url method

### DIFF
--- a/lib/omniauth/strategies/kakao.rb
+++ b/lib/omniauth/strategies/kakao.rb
@@ -12,7 +12,7 @@ module OmniAuth
         :authorize_path => '/oauth/authorize',
         :token_url => '/oauth/token',
       }
-
+      
       uid { raw_info['id'].to_s }
 
       info do
@@ -37,7 +37,10 @@ module OmniAuth
         options[:callback_path] = previous_callback_path
         super
       end
-
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+       
       def mock_call!(*)
         options.delete(:callback_path)
         super

--- a/lib/omniauth/strategies/kakao.rb
+++ b/lib/omniauth/strategies/kakao.rb
@@ -37,8 +37,19 @@ module OmniAuth
         options[:callback_path] = previous_callback_path
         super
       end
+      
+      # callback_uri와 관련해서 redirect_uri_mismatch 문제가 나오던것을 path match를 통해서 해결합니다.
+      # 해당 문제는 https://devtalk.kakao.com/t/rest-api-omniauth/19207 에서 나오는 문제를 해결합니다.
+      # NOTE If we're using code from the signed request then FB sets the redirect_uri to '' during the authorize
+      #      phase and it must match during the access_token phase:
+      #      https://github.com/facebook/facebook-php-sdk/blob/master/src/base_facebook.php#L477
       def callback_url
-        options[:redirect_uri] || (full_host + script_name + callback_path)
+        if @authorization_code_from_signed_request_in_cookie
+          ''
+        else
+          # callback url ignorance issue from https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
+          options[:callback_url] || (full_host + script_name + callback_path)
+        end
       end
        
       def mock_call!(*)


### PR DESCRIPTION
이 문제는 다음 문제와 관련이 있습니다.
https://devtalk.kakao.com/t/rest-api-omniauth/19207

devise와 gem omniauth_kakao를 연동하던 도중, kakao developers에서 callback url을 정상적으로 설정(users/auth/kakao/callback)했음에도 불구하고 redirect_uri_mismatch 문제가 발생했습니다.

그런데 omniauth_facebook도 비슷한 문제가 있었던 것을 보고 그 해결 과정을 동일하게 적용하니 정상 작동하였습니다.(callback_url_ignorace issue)
https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7

```
def callback_url
    if @authorization_code_from_signed_request_in_cookie
        ''
    else
        options[:callback_url] || (full_host + script_name + callback_path)
    end
end

```
